### PR TITLE
feat: Baseline dev tooling to support testing with CustomDA on EigenDA Proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -437,17 +437,38 @@ services:
 
   referenceda-provider:
     pid: host # allow debugging
-    image: nitro-node-dev-testnode
-    entrypoint: /usr/local/bin/daprovider
-    ports:
-      - "127.0.0.1:9880:9880"
-    volumes:
-      - "config:/config"
-      - "referenceda-provider-data:/data"
-      - "contracts:/contracts"
-      - "contracts-local:/contracts-local"
-    command:
-      - --conf.file=/config/referenceda_provider.json
+    image: ghcr.io/layr-labs/eigenda-proxy:dev
+    environment:
+      EIGENDA_PROXY_MEMSTORE_ENABLED: true
+      EIGENDA_PROXY_ARB_DA_PORT: 9880
+      EIGENDA_PROXY_APIS_TO_ENABLE: arb
+      EIGENDA_PROXY_STORAGE_BACKENDS_TO_ENABLE: V2
+      EIGENDA_PROXY_STORAGE_DISPERSAL_BACKEND: V2
+      EIGENDA_PROXY_STORAGE_CACHE_TARGETS: ""
+      EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX: "61ed8441f9781743271def8f1cc1639815d1fc5eee92aac44962a8c8f5268f51"
+      EIGENDA_PROXY_EIGENDA_V2_ETH_RPC: https://ethereum-sepolia.rpc.subquery.network/public
+      EIGENDA_PROXY_EIGENDA_V2_NETWORK: sepolia_testnet
+      EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH: 1MiB
+      EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ROUTER_OR_IMMUTABLE_VERIFIER_ADDR: 0x17ec4112c4BbD540E2c1fE0A49D264a280176F0D
+      EIGENDA_PROXY_EIGENDA_V2_RBN_RECENCY_WINDOW_SIZE: 0
+      EIGENDA_PROXY_EIGENDA_SIGNER_PRIVATE_KEY_HEX: "0000000000000000000100000000000000000000000000000000000000000000"
+      EIGENDA_PROXY_EIGENDA_ETH_RPC: https://ethereum-sepolia.rpc.subquery.network/public
+      EIGENDA_PROXY_EIGENDA_DISPERSER_RPC: disperser-testnet-sepolia.eigenda.xyz:443
+      EIGENDA_PROXY_EIGENDA_SERVICE_MANAGER_ADDR: 0x3a5acf46ba6890B8536420F4900AC9BC45Df4764
+      EIGENDA_PROXY_EIGENDA_CUSTOM_QUORUM_IDS: 
+      EIGENDA_PROXY_EIGENDA_CONFIRMATION_DEPTH: 6
+      EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH: 1MiB
+
+    # entrypoint: /usr/local/bin/daprovider
+    # ports:
+    #   - "127.0.0.1:9880:9880"
+    # volumes:
+    #   - "config:/config"
+    #   - "referenceda-provider-data:/data"
+    #   - "contracts:/contracts"
+    #   - "contracts-local:/contracts-local"
+    # command:
+    #   - --conf.file=/config/referenceda_provider.json
 
   timeboost-auctioneer:
     pid: host # allow debugging

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -266,9 +266,6 @@ function writeConfigs(argv: any) {
                     "enable": true,
                     "urls": ["http://das-mirror:9877"],
                 },
-                // TODO Fix das config to not need this redundant config
-                "parent-chain-node-url": argv.l1url,
-                "sequencer-inbox-address": "not_set"
             }
         },
         "execution": {
@@ -290,16 +287,15 @@ function writeConfigs(argv: any) {
         },
     }
 
-    baseConfig.node["data-availability"]["sequencer-inbox-address"] = ethers.utils.hexlify(getChainInfo()[0]["rollup"]["sequencer-inbox"]);
-
     if (argv.referenceDA) {
-        (baseConfig as any).node["da-provider"] = {
-            "enable": true,
-            "with-writer": false,
-            "rpc": {
-                "url": "http://referenceda-provider:9880"
-            },
-            "use-data-streaming": false
+        (baseConfig as any).node["da"] = {
+            "external-provider": {
+                "enable": true,
+                "with-writer": false,
+                "rpc": {
+                    "url": "http://referenceda-provider:9880"
+                }
+            }
         }
     }
 
@@ -308,7 +304,7 @@ function writeConfigs(argv: any) {
     if (argv.simple) {
         let simpleConfig = JSON.parse(baseConfJSON)
         simpleConfig.node.staker.enable = true
-        simpleConfig.node.staker["use-smart-contract-wallet"] = false // TODO: set to true when fixed
+        simpleConfig.node.staker["use-smart-contract-wallet"] = true
         simpleConfig.node.staker.dangerous["without-block-validator"] = true
         simpleConfig.node.sequencer = true
         simpleConfig.node.dangerous["no-sequencer-coordinator"] = true
@@ -323,7 +319,7 @@ function writeConfigs(argv: any) {
     } else {
         let validatorConfig = JSON.parse(baseConfJSON)
         validatorConfig.node.staker.enable = true
-        validatorConfig.node.staker["use-smart-contract-wallet"] = false // TODO: set to true when fixed
+        validatorConfig.node.staker["use-smart-contract-wallet"] = true
         let validconfJSON = JSON.stringify(validatorConfig)
         fs.writeFileSync(path.join(consts.configpath, "validator_config.json"), validconfJSON)
 
@@ -351,7 +347,7 @@ function writeConfigs(argv: any) {
             posterConfig.node["data-availability"]["rpc-aggregator"].enable = true
         }
         if (argv.referenceDA) {
-            posterConfig.node["da-provider"]["with-writer"] = true
+            posterConfig.node["da"]["external-provider"]["with-writer"] = true
         }
         fs.writeFileSync(path.join(consts.configpath, "poster_config.json"), JSON.stringify(posterConfig))
     }
@@ -365,7 +361,7 @@ function writeConfigs(argv: any) {
     const l3ChainInfoFile = path.join(consts.configpath, "l3_chain_info.json")
     l3Config.chain["info-files"] = [l3ChainInfoFile]
     l3Config.node.staker.enable = true
-    l3Config.node.staker["use-smart-contract-wallet"] = false // TODO: set to true when fixed
+    l3Config.node.staker["use-smart-contract-wallet"] = true
     l3Config.node.sequencer = true
     l3Config.execution["sequencer"].enable = true
     l3Config.node["dangerous"]["no-sequencer-coordinator"] = true
@@ -476,8 +472,10 @@ function writeL2DASCommitteeConfig(argv: any) {
                 "enable": true,
                 "enable-expiry": true
             },
-            "sequencer-inbox-address": sequencerInboxAddr,
-            "parent-chain-node-url": argv.l1url
+        },
+        "parent-chain": {
+            "node-url": argv.l1url,
+            "sequencer-inbox-address": sequencerInboxAddr
         },
         "enable-rest": true,
         "enable-rpc": true,
@@ -500,8 +498,6 @@ function writeL2DASMirrorConfig(argv: any, sequencerInboxAddr: string) {
                 "enable": true,
                 "enable-expiry": false
             },
-            "sequencer-inbox-address": sequencerInboxAddr,
-            "parent-chain-node-url": argv.l1url,
             "rest-aggregator": {
                 "enable": true,
                 "sync-to-storage": {
@@ -512,6 +508,10 @@ function writeL2DASMirrorConfig(argv: any, sequencerInboxAddr: string) {
                 },
                 "urls": ["http://das-committee-a:9877", "http://das-committee-b:9877"],
             }
+        },
+        "parent-chain": {
+            "node-url": argv.l1url,
+            "sequencer-inbox-address": sequencerInboxAddr
         },
         "enable-rest": true,
         "enable-rpc": false,

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -293,15 +293,13 @@ function writeConfigs(argv: any) {
     baseConfig.node["data-availability"]["sequencer-inbox-address"] = ethers.utils.hexlify(getChainInfo()[0]["rollup"]["sequencer-inbox"]);
 
     if (argv.referenceDA) {
-        (baseConfig as any).node["da"] = {
-            "mode": "external",
-            "external-provider": {
-                "enable": true,
-                "with-writer": false,
-                "rpc": {
-                    "url": "http://referenceda-provider:9880"
-                }
-            }
+        (baseConfig as any).node["da-provider"] = {
+            "enable": true,
+            "with-writer": false,
+            "rpc": {
+                "url": "http://referenceda-provider:9880"
+            },
+            "use-data-streaming": false
         }
     }
 
@@ -353,7 +351,7 @@ function writeConfigs(argv: any) {
             posterConfig.node["data-availability"]["rpc-aggregator"].enable = true
         }
         if (argv.referenceDA) {
-            posterConfig.node["da"]["external-provider"]["with-writer"] = true
+            posterConfig.node["da-provider"]["with-writer"] = true
         }
         fs.writeFileSync(path.join(consts.configpath, "poster_config.json"), JSON.stringify(posterConfig))
     }

--- a/test-node.bash
+++ b/test-node.bash
@@ -527,18 +527,20 @@ if $force_init; then
 
     if $l2referenceda; then
         docker compose run --rm --entrypoint sh referenceda-provider -c "true" # Noop to mount shared volumes with contracts for manual build and deployment
+        echo sleeping to give eigenda x customda server time startup
+        sleep 15s
 
-        echo "== Generating Reference DA keys"
-        docker compose run --rm --user root --entrypoint sh datool -c "mkdir /referenceda-provider/keys && chown -R 1000:1000 /referenceda-provider*"
-        docker compose run --rm datool keygen --dir /referenceda-provider/keys --ecdsa
+        # echo "== Generating Reference DA keys"
+        # docker compose run --rm --user root --entrypoint sh datool -c "mkdir /referenceda-provider/keys && chown -R 1000:1000 /referenceda-provider*"
+        # docker compose run --rm datool keygen --dir /referenceda-provider/keys --ecdsa
 
-        referenceDASignerAddress=`docker compose run --rm --entrypoint sh rollupcreator -c "cat /referenceda-provider/keys/ecdsa.pub | sed 's/^04/0x/' | tr -d '\n' | cast keccak | tail -c 41 | cast to-check-sum-address"`
+        # referenceDASignerAddress=`docker compose run --rm --entrypoint sh rollupcreator -c "cat /referenceda-provider/keys/ecdsa.pub | sed 's/^04/0x/' | tr -d '\n' | cast keccak | tail -c 41 | cast to-check-sum-address"`
 
-        echo "== Deploying Reference DA Proof Validator contract on L2"
-        l2referenceDAValidatorAddress=`docker compose run --rm --entrypoint sh rollupcreator -c "cd /contracts-local && forge create src/osp/ReferenceDAProofValidator.sol:ReferenceDAProofValidator --rpc-url http://geth:8545 --private-key $l2ownerKey --broadcast --constructor-args [$referenceDASignerAddress]" | awk '/Deployed to:/ {print $NF}'`
+        # echo "== Deploying Reference DA Proof Validator contract on L2"
+        # l2referenceDAValidatorAddress=`docker compose run --rm --entrypoint sh rollupcreator -c "cd /contracts-local && forge create src/osp/ReferenceDAProofValidator.sol:ReferenceDAProofValidator --rpc-url http://geth:8545 --private-key $l2ownerKey --broadcast --constructor-args [$referenceDASignerAddress]" | awk '/Deployed to:/ {print $NF}'`
 
-        echo "== Generating Reference DA Config"
-        run_script write-l2-referenceda-config --validator-address $l2referenceDAValidatorAddress
+        # echo "== Generating Reference DA Config"
+        # run_script write-l2-referenceda-config --validator-address $l2referenceDAValidatorAddress
     fi
 
 fi # $force_init


### PR DESCRIPTION
This is the first scaffolding step in constructing an agentic validation workflow which ensures correctness of the Arbitrum orbit stack wrt CustomDA JSON RPC server as part of EigenDA Proxy.

**Changes**
- Modifies the compose resource definition for `daprovider` to reference env and image for eigenda proxy with CustomDA enabled
- Nukes the CustomDA verifier contract deployment logic given we're **only supporting trusted integration**
- Adds a sleep call to the core orchestration script to ensure adequate time for the proxy JSON RPC server to startup